### PR TITLE
feat(nanvix): add bz_version.h and ignore build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ builddir
 *.lib
 *.obj
 *.res
+*.o

--- a/bz_version.h
+++ b/bz_version.h
@@ -1,0 +1,1 @@
+#define BZ_VERSION "1.0.8"


### PR DESCRIPTION
## Summary

Adds the `bz_version.h` header with the version string and updates `.gitignore` to exclude `.o` build artifacts.

## Motivation

The bootstrap script previously generated `bz_version.h` inline during the build. By committing it directly, cross-compilation environments can build bzip2 without extra file-generation steps.

## Changes
- **bz_version.h**: New file with `#define BZ_VERSION "1.0.8"`
- **.gitignore**: Add `*.o` pattern to ignore object files