### PR TITLE
[ci] E: Add bzip2 tests using nanvixd.elf in terminal mode

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -88,12 +88,17 @@ jobs:
         run: |
           make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" all
 
+      - name: Test
+        run: |
+          make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" test
+
       - name: Package Artifacts
         run: |
           set -euo pipefail
           ARTIFACT_NAME="bzip2-${{ matrix.platform }}-${{ matrix.process-mode }}"
           DIST_DIR="dist/${ARTIFACT_NAME}"
-          mkdir -p "${DIST_DIR}/lib" "${DIST_DIR}/include"
+          mkdir -p "${DIST_DIR}/bin" "${DIST_DIR}/lib" "${DIST_DIR}/include"
+          cp -f bzip2.elf "${DIST_DIR}/bin/" 2>/dev/null || true
           cp -f libbz2.a "${DIST_DIR}/lib/"
           cp -f bzlib.h "${DIST_DIR}/include/"
           tar -cjf "dist/${ARTIFACT_NAME}.tar.bz2" -C dist "${ARTIFACT_NAME}"

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -40,6 +40,8 @@ ifdef CONFIG_NANVIX
     $(info [INFO] Using Docker image $(NANVIX_DOCKER_IMAGE) (explicitly requested))
   endif
 
+  EXE=.elf
+
   ifdef CONFIG_NANVIX_DOCKER
     DOCKER_TOOLCHAIN_PATH := /opt/nanvix
     DOCKER_SYSROOT_PATH := /mnt/sysroot
@@ -54,29 +56,84 @@ ifdef CONFIG_NANVIX
       $(NANVIX_DOCKER_IMAGE)
     CC := $(DOCKER_RUN) $(DOCKER_TOOLCHAIN_PATH)/bin/i686-nanvix-gcc
     AR := $(DOCKER_RUN) $(DOCKER_TOOLCHAIN_PATH)/bin/i686-nanvix-ar
+    NANVIX_LDFLAGS := -T$(DOCKER_SYSROOT_PATH)/lib/user.ld -static -Wl,-z,noexecstack
+    NANVIX_LIBS := -Wl,--start-group
+    NANVIX_LIBS += $(DOCKER_SYSROOT_PATH)/lib/libposix.a
+    NANVIX_LIBS += $(DOCKER_TOOLCHAIN_PATH)/i686-nanvix/lib/libc.a
+    NANVIX_LIBS += $(DOCKER_TOOLCHAIN_PATH)/i686-nanvix/lib/libm.a
+    NANVIX_LIBS += -Wl,--end-group
   else
     CC := $(NANVIX_TOOLCHAIN)/bin/i686-nanvix-gcc
     AR := $(NANVIX_TOOLCHAIN)/bin/i686-nanvix-ar
+    NANVIX_LDFLAGS := -T$(NANVIX_HOME)/lib/user.ld -static -Wl,-z,noexecstack
+    NANVIX_LIBS := -Wl,--start-group
+    NANVIX_LIBS += $(NANVIX_HOME)/lib/libposix.a
+    NANVIX_LIBS += $(NANVIX_TOOLCHAIN)/i686-nanvix/lib/libc.a
+    NANVIX_LIBS += $(NANVIX_TOOLCHAIN)/i686-nanvix/lib/libm.a
+    NANVIX_LIBS += -Wl,--end-group
   endif
 else
   ifneq ($(MAKECMDGOALS),clean)
     $(error CONFIG_NANVIX must be set to 'y'. Usage: make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME=/path/to/nanvix)
   endif
+  EXE=.elf
 endif
 
-CFLAGS = -O2 -Wall -D_FILE_OFFSET_BITS=64
+CFLAGS = -O2 -Wall -D_FILE_OFFSET_BITS=64 -DBZ_UNIX -DBZ_LCCWIN32=0
 ARFLAGS = rcs
 STATICLIB = libbz2.a
 
 OBJS = blocksort.o huffman.o crctable.o randtable.o compress.o decompress.o bzlib.o
 
-all: $(STATICLIB)
+# Test executable
+TEST_PROGS = bzip2$(EXE)
+
+# All targets
+PROGS = $(STATICLIB) $(TEST_PROGS)
+
+all: $(PROGS)
 
 $(STATICLIB): $(OBJS)
 	$(AR) $(ARFLAGS) $@ $(OBJS)
 
+# bzip2 executable
+bzip2$(EXE): bzip2.o $(STATICLIB)
+	$(CC) $(CFLAGS) $(NANVIX_LDFLAGS) -o $@ bzip2.o -L. -lbz2 $(NANVIX_LIBS)
+
 %.o: %.c
 	$(CC) $(CFLAGS) -c -o $@ $<
+
+# Test target: run tests using nanvixd.elf
+test: $(TEST_PROGS)
+	@echo "Running bzip2 tests on Nanvix..."
+	@echo "Test 1: Compress and decompress roundtrip (sample1, -1)..."
+	cd "$(NANVIX_HOME)" && ./bin/nanvixd.elf -- $(abspath bzip2$(EXE)) -1 < $(abspath tests/sample1.ref) > /tmp/sample1.bz2
+	cd "$(NANVIX_HOME)" && ./bin/nanvixd.elf -- $(abspath bzip2$(EXE)) -d < /tmp/sample1.bz2 > /tmp/sample1.out
+	cmp /tmp/sample1.out tests/sample1.ref
+	@echo "		*** bzip2 sample1 roundtrip test OK ***"
+	@echo "Test 2: Compress and decompress roundtrip (sample2, -2)..."
+	cd "$(NANVIX_HOME)" && ./bin/nanvixd.elf -- $(abspath bzip2$(EXE)) -2 < $(abspath tests/sample2.ref) > /tmp/sample2.bz2
+	cd "$(NANVIX_HOME)" && ./bin/nanvixd.elf -- $(abspath bzip2$(EXE)) -d < /tmp/sample2.bz2 > /tmp/sample2.out
+	cmp /tmp/sample2.out tests/sample2.ref
+	@echo "		*** bzip2 sample2 roundtrip test OK ***"
+	@echo "Test 3: Compress and decompress roundtrip (sample3, -3)..."
+	cd "$(NANVIX_HOME)" && ./bin/nanvixd.elf -- $(abspath bzip2$(EXE)) -3 < $(abspath tests/sample3.ref) > /tmp/sample3.bz2
+	cd "$(NANVIX_HOME)" && ./bin/nanvixd.elf -- $(abspath bzip2$(EXE)) -ds < /tmp/sample3.bz2 > /tmp/sample3.out
+	cmp /tmp/sample3.out tests/sample3.ref
+	@echo "		*** bzip2 sample3 roundtrip test OK ***"
+	@echo "Test 4: Decompress reference file (sample1.bz2)..."
+	cd "$(NANVIX_HOME)" && ./bin/nanvixd.elf -- $(abspath bzip2$(EXE)) -d < $(abspath tests/sample1.bz2) > /tmp/sample1.dec
+	cmp /tmp/sample1.dec tests/sample1.ref
+	@echo "		*** bzip2 sample1 decompress test OK ***"
+	@echo "Test 5: Decompress reference file (sample2.bz2)..."
+	cd "$(NANVIX_HOME)" && ./bin/nanvixd.elf -- $(abspath bzip2$(EXE)) -d < $(abspath tests/sample2.bz2) > /tmp/sample2.dec
+	cmp /tmp/sample2.dec tests/sample2.ref
+	@echo "		*** bzip2 sample2 decompress test OK ***"
+	@echo "Test 6: Decompress reference file (sample3.bz2)..."
+	cd "$(NANVIX_HOME)" && ./bin/nanvixd.elf -- $(abspath bzip2$(EXE)) -ds < $(abspath tests/sample3.bz2) > /tmp/sample3.dec
+	cmp /tmp/sample3.dec tests/sample3.ref
+	@echo "		*** bzip2 sample3 decompress test OK ***"
+	@echo "All bzip2 tests passed."
 
 install: $(STATICLIB)
 	mkdir -p "$(DESTDIR)$(PREFIX)/lib"
@@ -85,6 +142,7 @@ install: $(STATICLIB)
 	install -m644 bzlib.h "$(DESTDIR)$(PREFIX)/include/"
 
 clean:
-	rm -f *.o $(STATICLIB)
+	rm -f *.o $(PROGS)
+	rm -f *.a *.elf
 
-.PHONY: all clean install
+.PHONY: all clean test install


### PR DESCRIPTION
## Summary

Add test infrastructure to build and run bzip2 tests on Nanvix using `nanvixd.elf` in terminal mode, following the same pattern used in the [zlib repository](https://github.com/nanvix/zlib).

## Changes

### Makefile.nanvix
- Add `NANVIX_LDFLAGS` and `NANVIX_LIBS` linker configuration (both Docker and native paths)
- Add `BZ_UNIX` and `BZ_LCCWIN32=0` compile definitions required by `bzip2.c`
- Build `bzip2.elf` executable linked against `libbz2.a` and Nanvix libraries
- Add `test` target with 6 tests run via `nanvixd.elf --`:
  - Tests 1-3: Compress + decompress roundtrip for sample1/2/3 (`-1`, `-2`, `-3`)
  - Tests 4-6: Decompress reference `.bz2` files and compare against `.ref` originals

### .github/workflows/nanvix-ci.yml
- Add **Test** step (`make ... test`) between Build and Package
- Include `bzip2.elf` in packaged release artifacts