### PR TITLE
[ci] add dispatch to cpython after release

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -176,6 +176,19 @@ jobs:
             --latest \
             release-assets/*.tar.bz2
 
+      - name: Trigger Dependent Workflows
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+        run: |
+          echo "Triggering cpython workflow..."
+          gh api repos/nanvix/cpython/dispatches \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -f event_type="bzip2-release" \
+            -f "client_payload[nanvix_sha]=${NANVIX_SHA}" \
+            -f "client_payload[bzip2_tag]=${GITHUB_SHA::7}-nanvix-${NANVIX_SHA}" || echo "::warning::Failed to trigger cpython workflow"
+
   report-failure:
     needs: [build]
     if: >-

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -104,34 +104,45 @@ bzip2$(EXE): bzip2.o $(STATICLIB)
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 # Test target: run tests using nanvixd.elf
+# Note: bzip2 is invoked with file arguments (-k -f) instead of stdin/stdout
+# redirects because nanvixd.elf terminal mode does not support shell redirects.
 test: $(TEST_PROGS)
 	@echo "Running bzip2 tests on Nanvix..."
 	@echo "Test 1: Compress and decompress roundtrip (sample1, -1)..."
-	cd "$(NANVIX_HOME)" && ./bin/nanvixd.elf -- $(abspath bzip2$(EXE)) -1 < $(abspath tests/sample1.ref) > /tmp/sample1.bz2
-	cd "$(NANVIX_HOME)" && ./bin/nanvixd.elf -- $(abspath bzip2$(EXE)) -d < /tmp/sample1.bz2 > /tmp/sample1.out
-	cmp /tmp/sample1.out tests/sample1.ref
+	cp $(abspath tests/sample1.ref) /tmp/sample1.ref
+	cd "$(NANVIX_HOME)" && ./bin/nanvixd.elf -- $(abspath bzip2$(EXE)) -1 -k -f /tmp/sample1.ref
+	cp /tmp/sample1.ref.bz2 /tmp/sample1_rt.bz2
+	cd "$(NANVIX_HOME)" && ./bin/nanvixd.elf -- $(abspath bzip2$(EXE)) -d -k -f /tmp/sample1_rt.bz2
+	cmp /tmp/sample1_rt $(abspath tests/sample1.ref)
 	@echo "		*** bzip2 sample1 roundtrip test OK ***"
 	@echo "Test 2: Compress and decompress roundtrip (sample2, -2)..."
-	cd "$(NANVIX_HOME)" && ./bin/nanvixd.elf -- $(abspath bzip2$(EXE)) -2 < $(abspath tests/sample2.ref) > /tmp/sample2.bz2
-	cd "$(NANVIX_HOME)" && ./bin/nanvixd.elf -- $(abspath bzip2$(EXE)) -d < /tmp/sample2.bz2 > /tmp/sample2.out
-	cmp /tmp/sample2.out tests/sample2.ref
+	cp $(abspath tests/sample2.ref) /tmp/sample2.ref
+	cd "$(NANVIX_HOME)" && ./bin/nanvixd.elf -- $(abspath bzip2$(EXE)) -2 -k -f /tmp/sample2.ref
+	cp /tmp/sample2.ref.bz2 /tmp/sample2_rt.bz2
+	cd "$(NANVIX_HOME)" && ./bin/nanvixd.elf -- $(abspath bzip2$(EXE)) -d -k -f /tmp/sample2_rt.bz2
+	cmp /tmp/sample2_rt $(abspath tests/sample2.ref)
 	@echo "		*** bzip2 sample2 roundtrip test OK ***"
 	@echo "Test 3: Compress and decompress roundtrip (sample3, -3)..."
-	cd "$(NANVIX_HOME)" && ./bin/nanvixd.elf -- $(abspath bzip2$(EXE)) -3 < $(abspath tests/sample3.ref) > /tmp/sample3.bz2
-	cd "$(NANVIX_HOME)" && ./bin/nanvixd.elf -- $(abspath bzip2$(EXE)) -ds < /tmp/sample3.bz2 > /tmp/sample3.out
-	cmp /tmp/sample3.out tests/sample3.ref
+	cp $(abspath tests/sample3.ref) /tmp/sample3.ref
+	cd "$(NANVIX_HOME)" && ./bin/nanvixd.elf -- $(abspath bzip2$(EXE)) -3 -k -f /tmp/sample3.ref
+	cp /tmp/sample3.ref.bz2 /tmp/sample3_rt.bz2
+	cd "$(NANVIX_HOME)" && ./bin/nanvixd.elf -- $(abspath bzip2$(EXE)) -ds -k -f /tmp/sample3_rt.bz2
+	cmp /tmp/sample3_rt $(abspath tests/sample3.ref)
 	@echo "		*** bzip2 sample3 roundtrip test OK ***"
 	@echo "Test 4: Decompress reference file (sample1.bz2)..."
-	cd "$(NANVIX_HOME)" && ./bin/nanvixd.elf -- $(abspath bzip2$(EXE)) -d < $(abspath tests/sample1.bz2) > /tmp/sample1.dec
-	cmp /tmp/sample1.dec tests/sample1.ref
+	cp $(abspath tests/sample1.bz2) /tmp/sample1_ref.bz2
+	cd "$(NANVIX_HOME)" && ./bin/nanvixd.elf -- $(abspath bzip2$(EXE)) -d -k -f /tmp/sample1_ref.bz2
+	cmp /tmp/sample1_ref $(abspath tests/sample1.ref)
 	@echo "		*** bzip2 sample1 decompress test OK ***"
 	@echo "Test 5: Decompress reference file (sample2.bz2)..."
-	cd "$(NANVIX_HOME)" && ./bin/nanvixd.elf -- $(abspath bzip2$(EXE)) -d < $(abspath tests/sample2.bz2) > /tmp/sample2.dec
-	cmp /tmp/sample2.dec tests/sample2.ref
+	cp $(abspath tests/sample2.bz2) /tmp/sample2_ref.bz2
+	cd "$(NANVIX_HOME)" && ./bin/nanvixd.elf -- $(abspath bzip2$(EXE)) -d -k -f /tmp/sample2_ref.bz2
+	cmp /tmp/sample2_ref $(abspath tests/sample2.ref)
 	@echo "		*** bzip2 sample2 decompress test OK ***"
 	@echo "Test 6: Decompress reference file (sample3.bz2)..."
-	cd "$(NANVIX_HOME)" && ./bin/nanvixd.elf -- $(abspath bzip2$(EXE)) -ds < $(abspath tests/sample3.bz2) > /tmp/sample3.dec
-	cmp /tmp/sample3.dec tests/sample3.ref
+	cp $(abspath tests/sample3.bz2) /tmp/sample3_ref.bz2
+	cd "$(NANVIX_HOME)" && ./bin/nanvixd.elf -- $(abspath bzip2$(EXE)) -ds -k -f /tmp/sample3_ref.bz2
+	cmp /tmp/sample3_ref $(abspath tests/sample3.ref)
 	@echo "		*** bzip2 sample3 decompress test OK ***"
 	@echo "All bzip2 tests passed."
 


### PR DESCRIPTION
Trigger cpython CI workflow when bzip2 releases a new build, completing the dependency chain: nanvix → bzip2 → cpython.

Stacked on top of PR #3.