### PR TITLE
ci: add cpython dispatch to nanvix-ci.yml

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -176,6 +176,21 @@ jobs:
             --latest \
             release-assets/*.tar.bz2
 
+      # Trigger dependent workflows (cpython depends on bzip2)
+      - name: Trigger Dependent Workflows
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+        run: |
+          RELEASE_TAG="${GITHUB_SHA::7}-nanvix-${NANVIX_SHA}"
+          echo "Triggering cpython workflow..."
+          gh api repos/nanvix/cpython/dispatches \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -f event_type="bzip2-release" \
+            -f "client_payload[nanvix_sha]=${NANVIX_SHA}" \
+            -f "client_payload[bzip2_tag]=${RELEASE_TAG}" || echo "::warning::Failed to trigger cpython workflow"
+
   report-failure:
     needs: [build]
     if: >-


### PR DESCRIPTION
Part of the upstream CI plan (Phase 2a).

bzip2 is a dependency of cpython. After a successful bzip2 release, this dispatches a `bzip2-release` event to `nanvix/cpython` so it rebuilds with the latest bzip2.

See: https://github.com/nanvix/nanvix-python/blob/main/UPSTREAM-CI-PLAN.md