### PR TITLE
ci: align workflow with validate-layer1.sh validations

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -124,7 +124,7 @@ jobs:
           fi
           echo "Package contents:"
           tar tjf "$TARBALL"
-          if ! tar tjf "$TARBALL" | grep -q 'sysroot/lib/'; then
+          if ! (set +o pipefail; tar tjf "$TARBALL" | grep -q 'sysroot/lib/'); then
             echo "::error::Package missing sysroot/lib/ entries"
             exit 1
           fi

--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -82,6 +82,7 @@ jobs:
           mkdir -p nanvix-artifacts/extracted
           tar -xjf "$ARTIFACT_FILE" -C nanvix-artifacts/extracted
           NANVIX_HOME=$(find nanvix-artifacts/extracted -maxdepth 2 -type d -name "bin" -exec dirname {} \; | head -1)
+          mkdir -p "$NANVIX_HOME/include"
           echo "NANVIX_HOME=$NANVIX_HOME" >> "$GITHUB_ENV"
 
       - name: Build
@@ -101,7 +102,7 @@ jobs:
 
       - name: Functional Tests
         run: |
-          make -f Makefile.nanvix CONFIG_NANVIX=y \
+          timeout --foreground 300 make -f Makefile.nanvix CONFIG_NANVIX=y \
             NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" test-functional
 
       - name: Package
@@ -112,6 +113,21 @@ jobs:
             package
           ARTIFACT_NAME="bzip2-${{ matrix.platform }}-${{ matrix.process-mode }}"
           echo "ARTIFACT_TARBALL=dist/${ARTIFACT_NAME}.tar.bz2" >> "$GITHUB_ENV"
+
+      - name: Verify Package
+        run: |
+          set -euo pipefail
+          if [[ ! -f "$ARTIFACT_TARBALL" ]]; then
+            echo "::error::Package tarball not found: $ARTIFACT_TARBALL"
+            exit 1
+          fi
+          if ! tar tjf "$ARTIFACT_TARBALL" | grep -q '^sysroot/lib/'; then
+            echo "::error::Package missing sysroot/lib/ entries"
+            tar tjf "$ARTIFACT_TARBALL"
+            exit 1
+          fi
+          echo "Package contents:"
+          tar tjf "$ARTIFACT_TARBALL"
 
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -117,17 +117,17 @@ jobs:
       - name: Verify Package
         run: |
           set -euo pipefail
-          if [[ ! -f "$ARTIFACT_TARBALL" ]]; then
-            echo "::error::Package tarball not found: $ARTIFACT_TARBALL"
-            exit 1
-          fi
-          if ! tar tjf "$ARTIFACT_TARBALL" | grep -q '^sysroot/lib/'; then
-            echo "::error::Package missing sysroot/lib/ entries"
-            tar tjf "$ARTIFACT_TARBALL"
+          TARBALL="dist/bzip2-${{ matrix.platform }}-${{ matrix.process-mode }}.tar.bz2"
+          if [[ ! -f "$TARBALL" ]]; then
+            echo "::error::Package tarball not found: $TARBALL"
             exit 1
           fi
           echo "Package contents:"
-          tar tjf "$ARTIFACT_TARBALL"
+          tar tjf "$TARBALL"
+          if ! tar tjf "$TARBALL" | grep -q 'sysroot/lib/'; then
+            echo "::error::Package missing sysroot/lib/ entries"
+            exit 1
+          fi
 
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Align the Nanvix CI workflow with validate-layer1.sh validations:
- Add mkdir -p for sysroot include directory
- Add timeout --foreground 300 to functional tests
- Add Verify Package step with pipefail-safe tar|grep check

Supersedes #9, #8.