### PR TITLE
ci: cancel superseded dispatch runs in workflow

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -18,6 +18,10 @@ permissions:
   actions: write
   issues: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name || github.ref || 'default' }}
+  cancel-in-progress: ${{ github.event_name == 'repository_dispatch' }}
+
 jobs:
   get-nanvix-info:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR updates CI workflow dispatch behavior to avoid redundant in-progress runs by enabling concurrency cancellation for repository_dispatch-triggered executions.