### PR TITLE
ci: implement best-effort release strategy

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -165,6 +165,7 @@ jobs:
             - uses: actions/checkout@v4
 
             - name: Download All Artifacts
+              id: download-artifacts
               uses: actions/download-artifact@v4
               continue-on-error: true
               with:
@@ -175,6 +176,9 @@ jobs:
               run: |
                   set -euo pipefail
                   mkdir -p release-assets
+                  if [[ "${{ steps.download-artifacts.outcome }}" == "failure" ]]; then
+                    echo "::warning::Artifact download step failed — this may indicate an API or network issue"
+                  fi
                   find release-artifacts -name "*.tar.bz2" -exec cp {} release-assets/ \; 2>/dev/null || true
                   ls -la release-assets/
 
@@ -182,8 +186,9 @@ jobs:
               run: |
                   set -euo pipefail
                   ASSET_COUNT=$(find release-assets -name "*.tar.bz2" 2>/dev/null | wc -l)
+                  echo "Found $ASSET_COUNT release asset(s)"
                   if [[ "$ASSET_COUNT" -eq 0 ]]; then
-                    echo "::error::No release assets found in release-assets/"
+                    echo "::error::No release assets found — all matrix builds may have failed or artifact retrieval encountered an error"
                     exit 1
                   fi
 
@@ -240,6 +245,7 @@ jobs:
         if: >-
             ${{ always() &&
                 (github.event_name == 'repository_dispatch' || github.event_name == 'schedule' || github.event_name == 'push') &&
+                needs.build.result == 'failure' &&
                 needs.release.result == 'failure' }}
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -159,13 +159,14 @@ jobs:
 
     release:
         needs: [get-nanvix-info, build]
-        if: github.event_name != 'pull_request'
+        if: ${{ !cancelled() && github.event_name != 'pull_request' }}
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
 
             - name: Download All Artifacts
               uses: actions/download-artifact@v4
+              continue-on-error: true
               with:
                   path: release-artifacts
                   pattern: bzip2-*
@@ -174,7 +175,7 @@ jobs:
               run: |
                   set -euo pipefail
                   mkdir -p release-assets
-                  find release-artifacts -name "*.tar.bz2" -exec cp {} release-assets/ \;
+                  find release-artifacts -name "*.tar.bz2" -exec cp {} release-assets/ \; 2>/dev/null || true
                   ls -la release-assets/
 
             - name: Verify Release Assets
@@ -235,11 +236,11 @@ jobs:
                     -f "client_payload[bzip2_tag]=${RELEASE_TAG}" || echo "::warning::Failed to trigger cpython workflow"
 
     report-failure:
-        needs: [build]
+        needs: [build, release]
         if: >-
             ${{ always() &&
                 (github.event_name == 'repository_dispatch' || github.event_name == 'schedule' || github.event_name == 'push') &&
-                needs.build.result == 'failure' }}
+                needs.release.result == 'failure' }}
         runs-on: ubuntu-latest
         steps:
             - name: Create failure issue


### PR DESCRIPTION
## Summary

Refactor nanvix-ci.yml so that the CI pipeline publishes a release containing only the binaries from matrix configurations that passed testing. The pipeline now fails only when ALL matrix legs fail.

## Changes

- **Download All Artifacts step**: add continue-on-error: true to handle zero artifacts gracefully
- **Prepare Release Assets step**: add asset count check that exits 1 only when zero artifacts exist (all legs failed)
- **report-failure job**: depend on release job and trigger only when release fails (i.e., all matrix legs failed)

## Behavior

| Scenario | Build result | Release runs? | Release result | Failure reported? |
|---|---|---|---|---|
| All 5 legs pass | success | yes | success (5 artifacts) | no |
| 3/5 legs pass | failure | yes | success (3 artifacts) | no |
| 0/5 legs pass | failure | yes | failure (0 artifacts) | yes |
| Workflow cancelled | - | no (cancelled) | skipped | no |

## Safeguards

- fail-fast: false (already present) ensures all matrix legs complete independently
- Upload steps use if: success() (default), so only passing legs produce artifacts
