### PR TITLE
[ci] E: Upgrade reusable workflow to v1.1.0

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.0.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.1.0
     with:
       zutil-version: "v0.4.0"
       caller-event-name: ${{ github.event_name }}


### PR DESCRIPTION
## Summary

Upgrade the reusable CI workflow reference from `nanvix/workflows@v1.0.0` to `@v1.1.0`.

## What v1.1.0 adds

- **Automatic issue reporting** — opens a GitHub issue when a scheduled CI run fails on the default branch, with repo admin assignment and occurrence deduplication
- **Workflow linting** — actionlint runs on every push/PR to the workflows repo, catching errors before merge

## Changes

Single-line change in `.github/workflows/nanvix-ci.yml`:
```diff
- uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.0.0
+ uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.1.0
```

## Motivation

The recent scheduled CI failure in this repo (functional test crash on hyperlight, run #365) went unnoticed because there was no mechanism to report it. This upgrade enables automatic issue creation for future failures.