### PR TITLE
[ci] Disable hyperlight single-process and multi-process in CI

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -25,9 +25,10 @@ concurrency:
 
 jobs:
   ci:
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.0.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.2.0
     with:
       zutil-version: "v0.4.0"
+      matrix-exclude: '[{"platform":"hyperlight","process-mode":"single-process"},{"platform":"hyperlight","process-mode":"multi-process"}]'
       caller-event-name: ${{ github.event_name }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Exclude hyperlight single-process and multi-process from the CI build matrix while keeping hyperlight standalone enabled.

## Changes

Upgrade to `nanvix/workflows@v1.2.0` and use the new `matrix-exclude` input to exclude only the failing combinations:

```diff
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.0.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.2.0
     with:
       zutil-version: "v0.4.0"
+      matrix-exclude: '[{"platform":"hyperlight","process-mode":"single-process"},{"platform":"hyperlight","process-mode":"multi-process"}]'
       caller-event-name: ${{ github.event_name }}
```

### Matrix after this change

| Platform | standalone | single-process | multi-process |
|---|---|---|---|
| microvm | ✅ | ✅ | ✅ |
| hyperlight | ✅ | ❌ | ❌ |

## Motivation

Scheduled CI runs fail consistently on `hyperlight-single-process-128mb` and `hyperlight-multi-process-128mb` where nanvixd v0.12.291 exits with error 202 during bzip2 functional tests. This is a platform-level issue, not a bzip2 problem.

Disabling only the affected combinations unblocks CI while keeping hyperlight standalone coverage. The `matrix-exclude` input was added in [nanvix/workflows v1.2.0](https://github.com/nanvix/workflows/releases/tag/v1.2.0) specifically to support this use case.