### PR TITLE
[ci] E: Update nanvix workflow refs to v1.3.0

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.2.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.3.0
     with:
       zutil-version: "v0.6.0"
       memory-sizes: '["128mb","256mb"]'


### PR DESCRIPTION
Automated bump of `nanvix/workflows` references to [`v1.3.0`](https://github.com/nanvix/workflows/releases/tag/v1.3.0).

Generated by the [Update Workflow Refs](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-workflows.yml) workflow.