### PR TITLE
[ci] Add pull-requests write permission for scheduled runs

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -23,6 +23,23 @@ concurrency:
 
 jobs:
   ci:
+    if: github.event_name != 'schedule'
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.4.0
+    with:
+      zutil-version: "v0.7.3"
+      memory-sizes: '["128mb","256mb"]'
+      matrix-exclude: '[{"platform":"hyperlight","process-mode":"single-process"},{"platform":"hyperlight","process-mode":"multi-process"}]'
+      caller-event-name: ${{ github.event_name }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+
+  ci-scheduled:
+    if: github.event_name == 'schedule'
+    permissions:
+      contents: write
+      actions: write
+      issues: write
+      pull-requests: write
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.4.0
     with:
       zutil-version: "v0.7.3"


### PR DESCRIPTION
## Summary

Add `pull-requests: write` to the caller workflow permissions block to fix the nightly scheduled CI failure.

## Problem

Since April 5, all scheduled runs fail on the `Update Nanvix Version` job with:

```
pull request create failed: GraphQL: Resource not accessible by integration (createPullRequest)
```

The `update-nanvix-version` job (introduced in `nanvix/workflows` v1.3.x) needs `pull-requests: write` to create version-bump PRs. The caller only grants `contents`, `actions`, and `issues` — so the reusable workflow cannot exceed that scope.

## Fix

Add `pull-requests: write` to the `permissions` block in the caller workflow.