### PR TITLE
fix(z.py): skip build prerequisite in make test

### DIFF
--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -80,7 +80,12 @@ class Bzip2Build(ZScript):
             self._run_tests_windows()
             return
         targets = self.targets if self.targets else ["test"]
-        self.run(*self._make_args(*targets), cwd=self.repo_root)
+        args = self._make_args(*targets)
+        # Skip the build prerequisite — the build phase already ran
+        # (possibly inside Docker, which bakes container paths into
+        # generated files that do not exist on the host).
+        args[1:1] = ["-o", "build", "-o", "all"]
+        self.run(*args, cwd=self.repo_root)
 
     def _run_tests_windows(self) -> None:
         """Run tests natively on Windows using nanvixd.exe."""


### PR DESCRIPTION
Pass `-o build -o all` to make during the test phase so that the build target is treated as already up-to-date.

When building inside Docker (`--with-docker`), configure and make bake container paths (`/mnt/workspace`, `/mnt/sysroot`) into generated files. If `make test` then runs natively on the host, the `build` prerequisite triggers a rebuild that reads those Docker-era paths and fails.

This change tells make to consider `build` and `all` already done, so only the test targets execute. `-o` is a no-op when the target is not in the dependency chain, so native-only workflows are unaffected.
