### PR TITLE
fix(Makefile.nanvix): use absolute path for nanvixd binary argument

### DIFF
--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -168,7 +168,7 @@ ifdef CONFIG_NANVIX_DOCKER
 	  ./bin/mkramfs.elf -o /tmp/rootfs.img /tmp/nanvix-ramfs/ && \
 	  timeout --foreground 120 ./bin/nanvixd.elf \
 	    -bin-dir ./bin -ramfs /tmp/rootfs.img \
-	    -- ./bzip2$(EXE) -1 -k -f /tmp/sample1.ref && \
+	    -- $(abspath bzip2$(EXE)) -1 -k -f /tmp/sample1.ref && \
 	  echo "  PASS: sample1 compress standalone" || \
 	  { echo "  FAIL: sample1 compress standalone"; exit 1; }'
 	@echo "  Running standalone decompress test via nanvixd.elf (Docker)..."
@@ -179,7 +179,7 @@ ifdef CONFIG_NANVIX_DOCKER
 	  ./bin/mkramfs.elf -o /tmp/rootfs.img /tmp/nanvix-ramfs/ && \
 	  timeout --foreground 120 ./bin/nanvixd.elf \
 	    -bin-dir ./bin -ramfs /tmp/rootfs.img \
-	    -- ./bzip2$(EXE) -d -k -f /tmp/sample1_ref.bz2 && \
+	    -- $(abspath bzip2$(EXE)) -d -k -f /tmp/sample1_ref.bz2 && \
 	  echo "  PASS: sample1 decompress standalone" || \
 	  { echo "  FAIL: sample1 decompress standalone"; exit 1; }'
 else
@@ -190,7 +190,7 @@ else
 	"$(SYSROOT_PATH)/bin/mkramfs.elf" -o /tmp/rootfs.img /tmp/nanvix-ramfs/
 	cd "$(SYSROOT_PATH)" && timeout --foreground 120 ./bin/nanvixd.elf \
 	  -bin-dir ./bin -ramfs /tmp/rootfs.img \
-	  -- ./bzip2$(EXE) -1 -k -f /tmp/sample1.ref
+	  -- $(abspath bzip2$(EXE)) -1 -k -f /tmp/sample1.ref
 	@echo "  PASS: sample1 compress standalone"
 	@echo "  Test 2: Standalone decompress reference (sample1.bz2)..."
 	@rm -rf /tmp/nanvix-ramfs && mkdir -p /tmp/nanvix-ramfs/tmp
@@ -199,7 +199,7 @@ else
 	"$(SYSROOT_PATH)/bin/mkramfs.elf" -o /tmp/rootfs.img /tmp/nanvix-ramfs/
 	cd "$(SYSROOT_PATH)" && timeout --foreground 120 ./bin/nanvixd.elf \
 	  -bin-dir ./bin -ramfs /tmp/rootfs.img \
-	  -- ./bzip2$(EXE) -d -k -f /tmp/sample1_ref.bz2
+	  -- $(abspath bzip2$(EXE)) -d -k -f /tmp/sample1_ref.bz2
 	@rm -rf /tmp/nanvix-ramfs /tmp/rootfs.img
 	@echo "  PASS: sample1 decompress standalone"
 endif


### PR DESCRIPTION
nanvixd uses mmap() to load the user binary from the host filesystem path given after `--`. The standalone non-Docker test recipe does `cd $(SYSROOT_PATH)` before invoking nanvixd, so `./binary.elf` resolves relative to the sysroot — where the binary does not exist.

Replace relative paths with `$(abspath ...)` so nanvixd can find the binary regardless of the working directory. The non-standalone recipes already used `$(abspath ...)` correctly.

Part of nanvix/zutils#130.