### PR TITLE
feat: add Windows build, test, and CI support

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -31,6 +31,7 @@ jobs:
       memory-sizes: '["128mb","256mb"]'
       matrix-exclude: '[{"platform":"hyperlight","process-mode":"single-process"},{"platform":"hyperlight","process-mode":"multi-process"}]'
       caller-event-name: ${{ github.event_name }}
+      windows-test: false
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
@@ -48,6 +49,41 @@ jobs:
       memory-sizes: '["128mb","256mb"]'
       matrix-exclude: '[{"platform":"hyperlight","process-mode":"single-process"},{"platform":"hyperlight","process-mode":"multi-process"}]'
       caller-event-name: 'schedule'
+      windows-test: false
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+
+  # -------------------------------------------------------------------
+  # Windows CI: cross-compile via Docker, then test locally.
+  # The reusable workflow's windows-test is disabled (windows-test: false)
+  # because it only runs setup+test (no build). bzip2 requires Docker to
+  # cross-compile, so we use a self-hosted Windows runner with Docker.
+  # -------------------------------------------------------------------
+  ci-windows:
+    needs: [ci, ci-scheduled]
+    if: >-
+      !cancelled() &&
+      (needs.ci.result == 'success' || needs.ci-scheduled.result == 'success')
+    runs-on: [self-hosted, Windows]
+    timeout-minutes: 30
+    env:
+      GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Setup
+        shell: pwsh
+        run: .\z.ps1 setup
+
+      - name: Build (cross-compile via Docker)
+        shell: pwsh
+        run: .\z.ps1 --with-docker build
+
+      - name: Test (run locally via nanvixd.exe)
+        shell: pwsh
+        run: .\z.ps1 test

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -4,18 +4,30 @@
 """Nanvix build script for bzip2.
 
 Usage:
-    ./z setup     # Download Nanvix sysroot
-    ./z build     # Cross-compile libbz2.a
-    ./z test      # Run test suite (smoke + integration + functional)
-    ./z release   # Package release tarball
-    ./z clean     # Remove build artifacts
+    ./z setup                  # Download Nanvix sysroot
+    ./z build                  # Cross-compile (Linux, or Docker container)
+    ./z build --with-docker    # Cross-compile via Docker (required on Windows)
+    ./z test                   # Run test suite
+    ./z release                # Package release tarball
+    ./z clean                  # Remove build artifacts
 """
 
+import dataclasses
+import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
-from nanvix_zutil import CFG_SYSROOT, CFG_TOOLCHAIN, EXIT_MISSING_DEP, ZScript, log
+from nanvix_zutil import (
+    CFG_SYSROOT,
+    CFG_TOOLCHAIN,
+    EXIT_MISSING_DEP,
+    DockerConfig,
+    ZScript,
+    is_windows,
+    log,
+)
 
 # Makefile variable names (build-system-specific).
 _MAKE_VAR_CONFIG = "CONFIG_NANVIX"
@@ -25,15 +37,19 @@ _MAKE_VAR_PLATFORM = "PLATFORM"
 _MAKE_VAR_PROCESS_MODE = "PROCESS_MODE"
 _MAKE_VAR_MEMORY_SIZE = "MEMORY_SIZE"
 
+# Build output files that must be copied back from the Docker container
+# to the host workspace after a Windows Docker build.
+_BUILD_OUTPUT_FILES = [
+    "libbz2.a",
+    "bzip2.elf",
+]
 
-
-IS_WINDOWS = sys.platform == "win32"
 
 class Bzip2Build(ZScript):
     """Build script for nanvix/bzip2."""
 
-    def _make_args(self, *targets: str) -> list[str]:
-        """Build the common make argument list."""
+    def _get_sysroot(self) -> str:
+        """Return the sysroot path, or fatal if not set."""
         sysroot = self.config.get(CFG_SYSROOT, "")
         if not sysroot:
             log.fatal(
@@ -41,123 +57,229 @@ class Bzip2Build(ZScript):
                 code=EXIT_MISSING_DEP,
                 hint="Run `./z setup` first to download the sysroot.",
             )
+        return sysroot
+
+    def _make_args(self, *targets: str) -> list[str]:
+        """Build the common make argument list."""
+        sysroot = self._get_sysroot()
         toolchain = self.config.get(CFG_TOOLCHAIN, "/opt/nanvix")
         sysroot_p = self.translate_path(Path(sysroot))
-        toolchain_p = self.translate_path(Path(toolchain))
+
+        # The toolchain path lives inside the Docker container
+        # (/opt/nanvix) and is not a host path. Avoid passing it through
+        # Path() on Windows which would mangle the forward slashes.
+        if self.docker is not None:
+            toolchain_p = toolchain
+        else:
+            toolchain_p = self.translate_path(Path(toolchain))
 
         args = [
             "make", "-f", "Makefile.nanvix",
             f"{_MAKE_VAR_CONFIG}=y",
             f"{_MAKE_VAR_HOME}={sysroot_p}",
             f"{_MAKE_VAR_TOOLCHAIN}={toolchain_p}",
-        ]
-
-        args.extend([
             f"{_MAKE_VAR_PLATFORM}={self.config.machine}",
             f"{_MAKE_VAR_PROCESS_MODE}={self.config.deployment_mode}",
             f"{_MAKE_VAR_MEMORY_SIZE}={self.config.memory_size}",
-        ])
-
+        ]
         args.extend(targets)
         return args
+
+    # ------------------------------------------------------------------
+    # Docker configuration
+    # ------------------------------------------------------------------
+
+    def docker_config(self, image: str) -> DockerConfig:
+        """Build Docker configuration with bzip2 output files.
+
+        Extends the base class configuration to specify which build
+        artifacts must be copied back from the container to the host
+        workspace after a Windows Docker build.
+        """
+        cfg = super().docker_config(image)
+        return dataclasses.replace(cfg, output_files=_BUILD_OUTPUT_FILES)
+
+    # ------------------------------------------------------------------
+    # Setup
+    # ------------------------------------------------------------------
 
     def setup(self) -> None:
         """Download the Nanvix sysroot."""
         super().setup()
 
+    # ------------------------------------------------------------------
+    # Build
+    # ------------------------------------------------------------------
+
     def build(self) -> None:
-        """Cross-compile libbz2.a for Nanvix."""
-        self.run(*self._make_args("all"), cwd=self.repo_root)
+        """Cross-compile libbz2.a and bzip2.elf for Nanvix.
+
+        Uses ``self.run()`` which transparently wraps in Docker when
+        ``--with-docker`` is passed. On Linux CI the build runs inside
+        the toolchain container directly. On Windows, pass
+        ``--with-docker`` to cross-compile via Docker Desktop.
+        """
+        self.run(*self._make_args("all", "bzip2.elf"), cwd=self.repo_root)
+
+    # ------------------------------------------------------------------
+    # Test
+    # ------------------------------------------------------------------
 
     def test(self) -> None:
         """Run the test suite.
 
-        On non-Windows, delegates to the Makefile (smoke + integration + functional).
-        On Windows, runs test binaries from build/ via nanvixd.exe natively,
-        following the same pattern as posix-tests and cpython.
+        On Linux, delegates to the Makefile (smoke + integration + functional).
+        On Windows, runs bzip2.elf through nanvixd.exe in standalone mode
+        with compress/decompress tests.
         """
-        if IS_WINDOWS:
+        if is_windows():
             self._run_tests_windows()
             return
         targets = self.targets if self.targets else ["test"]
         self.run(*self._make_args(*targets), cwd=self.repo_root)
 
     def _run_tests_windows(self) -> None:
-        """Run tests natively on Windows using nanvixd.exe."""
-        sysroot = self.config.get(CFG_SYSROOT, "")
-        if not sysroot:
-            log.fatal(f"{CFG_SYSROOT} is not set.", code=EXIT_MISSING_DEP, hint="Run `./z setup` first.")
+        """Run bzip2 standalone tests on Windows using nanvixd.exe.
+
+        Expects bzip2.elf to already exist (from a prior ``./z build
+        --with-docker``). Runs compress and decompress tests via
+        nanvixd.exe + mkramfs.exe in standalone mode.
+        """
+        sysroot = self._get_sysroot()
         sysroot_path = Path(sysroot)
+
         nanvixd = sysroot_path / "bin" / "nanvixd.exe"
         mkramfs = sysroot_path / "bin" / "mkramfs.exe"
         if not nanvixd.is_file():
-            log.fatal("nanvixd.exe not found.", code=EXIT_MISSING_DEP, hint="Run `./z setup` first.")
+            log.fatal(
+                "nanvixd.exe not found.",
+                code=EXIT_MISSING_DEP,
+                hint="Run `./z setup` first.",
+            )
         if not mkramfs.is_file():
-            log.fatal("mkramfs.exe not found.", code=EXIT_MISSING_DEP, hint="Run `./z setup` first.")
+            log.fatal(
+                "mkramfs.exe not found.",
+                code=EXIT_MISSING_DEP,
+                hint="Run `./z setup` first.",
+            )
 
-        build_dir = self.repo_root / "build"
-        test_binaries = sorted(build_dir.glob("*.elf")) if build_dir.is_dir() else []
+        bzip2_elf = self.repo_root / "bzip2.elf"
+        if not bzip2_elf.is_file():
+            log.fatal(
+                "bzip2.elf not found.",
+                code=EXIT_MISSING_DEP,
+                hint="Run `./z build --with-docker` first.",
+            )
 
-        if not test_binaries:
-            print("No test binaries found in build/ -- smoke test only.")
-            print("OK: library-only repo, no functional tests to run on Windows")
-            return
+        sample_ref = self.repo_root / "tests" / "sample1.ref"
+        sample_bz2 = self.repo_root / "tests" / "sample1.bz2"
+        if not sample_ref.is_file() or not sample_bz2.is_file():
+            log.fatal(
+                "Test data not found (tests/sample1.ref or tests/sample1.bz2).",
+                code=EXIT_MISSING_DEP,
+            )
 
-        import shutil
-        import tempfile
-        failed = []
-        for binary in test_binaries:
-            name = binary.stem
-            print(f"RUN  {name}...")
-            with tempfile.TemporaryDirectory(prefix=f"nanvix_{name}_") as tmpdir:
-                tmpdir_path = Path(tmpdir)
-                ramfs_dir = tmpdir_path / "ramfs"
-                ramfs_dir.mkdir()
-                (ramfs_dir / "tmp").mkdir(exist_ok=True)
-                shutil.copy2(binary, ramfs_dir / binary.name)
-                # Write ramfs image alongside the ramfs source dir to avoid
-                # self-inclusion while keeping artifacts scoped to this temp dir.
-                ramfs_img = tmpdir_path / f"rootfs_{name}.img"
-                try:
-                    subprocess.run(
-                        [str(mkramfs.resolve()), "-o", str(ramfs_img), str(ramfs_dir)],
-                        check=True, timeout=60,
-                    )
-                except subprocess.CalledProcessError as e:
-                    print(f"FAIL {name} (mkramfs exit code {e.returncode})")
-                    failed.append(name)
-                    continue
-                except subprocess.TimeoutExpired:
-                    print(f"FAIL {name} (mkramfs timeout)")
-                    failed.append(name)
-                    continue
-                try:
-                    result = subprocess.run(
-                        [str(nanvixd.resolve()), "-bin-dir", str((sysroot_path / "bin").resolve()),
-                         "-ramfs", str(ramfs_img), "--", f"./{binary.name}"],
-                        stdin=subprocess.DEVNULL, timeout=120,
-                    )
-                    if result.returncode != 0:
-                        print(f"FAIL {name} (exit code {result.returncode})")
-                        failed.append(name)
-                    else:
-                        print(f"OK   {name}")
-                except subprocess.TimeoutExpired:
-                    print(f"FAIL {name} (timeout)")
-                    failed.append(name)
+        bin_dir = str((sysroot_path / "bin").resolve())
 
-        if failed:
-            msg = " ".join(failed)
-            raise RuntimeError(f"{len(failed)} test(s) failed: {msg}")
-        print(f"\t\t*** All {len(test_binaries)} tests PASSED ***")
+        print("=== bzip2 standalone compress test ===")
+        self._run_nanvixd_test(
+            label="sample1 compress standalone",
+            bzip2_elf=bzip2_elf,
+            test_file=sample_ref,
+            test_file_guest_name="sample1.ref",
+            nanvixd=nanvixd, mkramfs=mkramfs, bin_dir=bin_dir,
+            bzip2_args=["-1", "-k", "-f", "/tmp/sample1.ref"],
+        )
+
+        print("=== bzip2 standalone decompress test ===")
+        self._run_nanvixd_test(
+            label="sample1 decompress standalone",
+            bzip2_elf=bzip2_elf,
+            test_file=sample_bz2,
+            test_file_guest_name="sample1.bz2",
+            nanvixd=nanvixd, mkramfs=mkramfs, bin_dir=bin_dir,
+            bzip2_args=["-d", "-k", "-f", "/tmp/sample1.bz2"],
+        )
+
+        print("=== All bzip2 Windows tests PASSED ===")
+
+    def _run_nanvixd_test(
+        self,
+        *,
+        label: str,
+        bzip2_elf: Path,
+        test_file: Path,
+        test_file_guest_name: str,
+        nanvixd: Path,
+        mkramfs: Path,
+        bin_dir: str,
+        bzip2_args: list[str],
+    ) -> None:
+        """Run a single bzip2 test inside nanvixd.exe."""
+        tmpdir_path = Path(tempfile.mkdtemp(prefix="nanvix_bzip2_"))
+        try:
+            ramfs_dir = tmpdir_path / "ramfs"
+            ramfs_dir.mkdir()
+            (ramfs_dir / "tmp").mkdir()
+            shutil.copy2(bzip2_elf, ramfs_dir / "bzip2.elf")
+            shutil.copy2(test_file, ramfs_dir / "tmp" / test_file_guest_name)
+            ramfs_img = tmpdir_path / "rootfs.img"
+
+            subprocess.run(
+                [str(mkramfs.resolve()), "-o", str(ramfs_img), str(ramfs_dir)],
+                check=True, timeout=60,
+            )
+
+            cmd = [
+                str(nanvixd.resolve()),
+                "-bin-dir", bin_dir,
+                "-ramfs", str(ramfs_img),
+                "--", "./bzip2.elf", *bzip2_args,
+            ]
+            result = subprocess.run(
+                cmd,
+                stdin=subprocess.DEVNULL,
+                capture_output=True, text=True,
+                timeout=120,
+            )
+            if result.stdout:
+                print(result.stdout, end="")
+            if result.stderr:
+                print(result.stderr, end="")
+            if result.returncode != 0:
+                raise RuntimeError(
+                    f"{label} failed (exit code {result.returncode})"
+                )
+            print(f"  PASS: {label}")
+        except subprocess.TimeoutExpired:
+            raise RuntimeError(f"{label} timed out (120s)")
+        finally:
+            shutil.rmtree(tmpdir_path, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+    # Release
+    # ------------------------------------------------------------------
 
     def release(self) -> None:
         """Package the bzip2 release tarball and verify it."""
         self.run(*self._make_args("package"), cwd=self.repo_root)
         self.run(*self._make_args("verify-package"), cwd=self.repo_root)
 
+    # ------------------------------------------------------------------
+    # Clean
+    # ------------------------------------------------------------------
+
     def clean(self) -> None:
         """Remove build artifacts."""
+        if is_windows():
+            for pattern in ["*.o", "*.a", "*.elf"]:
+                for f in self.repo_root.glob(pattern):
+                    f.unlink()
+            dist_dir = self.repo_root / "dist"
+            if dist_dir.exists():
+                shutil.rmtree(dist_dir)
+            print("Cleaned build artifacts")
+            return
         self.run(
             "make", "-f", "Makefile.nanvix", "clean",
             cwd=self.repo_root,


### PR DESCRIPTION
Closes #99

Add Windows support for bzip2 cross-compilation and testing.

### .nanvix/z.py
- **build()**: builds libbz2.a + bzip2.elf. Uses self.run() with transparent Docker wrapping via --with-docker flag.
- **docker_config()**: overrides base class to specify output_files (libbz2.a, bzip2.elf) copied back from Docker container to host.
- **test()**: on Windows, runs bzip2.elf through nanvixd.exe + mkramfs.exe in standalone mode with sample1 compress/decompress tests.
- **clean()**: Windows-aware cleanup of build artifacts.
- Toolchain path fix: when Docker is active, passes /opt/nanvix as string (avoids Windows Path() mangling forward slashes).

### .github/workflows/nanvix-ci.yml
- Disables reusable workflow's windows-test (it only does setup+test, no build).
- Adds ci-windows job on self-hosted Windows runner with Docker: setup -> build --with-docker -> test.

### Tested locally
- Windows: z.ps1 --with-docker build (Docker cross-compile) + z.ps1 test (nanvixd.exe) -> PASS
- Linux/WSL: ./z build (auto-detects Docker) + ./z test -- test-smoke test-integration -> PASS
- Linux/WSL: ./z --with-docker build -> PASS