### PR TITLE
Enable hyperlight multi-process and single-process modes

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -28,11 +28,12 @@ jobs:
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.12.0
     with:
       zutil-version: "v0.7.26"
+      platforms: '["hyperlight","microvm"]'
+      process-modes: '["multi-process","single-process","standalone"]'
       memory-sizes: '["128mb","256mb"]'
-      matrix-exclude: '[{"platform":"hyperlight","process-mode":"single-process"},{"platform":"hyperlight","process-mode":"multi-process"}]'
+      skip-full-test-modes: '[]'
       caller-event-name: ${{ github.event_name }}
       windows-test: true
-      skip-full-test-modes: '[]'
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
@@ -47,11 +48,12 @@ jobs:
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.12.0
     with:
       zutil-version: "v0.7.26"
+      platforms: '["hyperlight","microvm"]'
+      process-modes: '["multi-process","single-process","standalone"]'
       memory-sizes: '["128mb","256mb"]'
-      matrix-exclude: '[{"platform":"hyperlight","process-mode":"single-process"},{"platform":"hyperlight","process-mode":"multi-process"}]'
+      skip-full-test-modes: '[]'
       caller-event-name: 'schedule'
       windows-test: true
-      skip-full-test-modes: '[]'
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}

--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -8,11 +8,3 @@ nanvix-version = "0.12.472"
 platforms = ["hyperlight", "microvm"]
 modes = ["multi-process", "single-process", "standalone"]
 memory = ["128mb", "256mb"]
-
-[[builds.exclude]]
-platform = "hyperlight"
-mode = "single-process"
-
-[[builds.exclude]]
-platform = "hyperlight"
-mode = "multi-process"


### PR DESCRIPTION
Remove the `[[builds.exclude]]` entries for hyperlight+single-process and hyperlight+multi-process from `nanvix.toml`, and remove the `matrix-exclude` from the CI workflow.

## Background

These modes were disabled in commit d315ce6 (2026-03-29) because bzip2 functional tests failed with error 202 on the hyperlight runtime at that time.

Since then, the Nanvix runtime has been updated to v0.12.472, and **all other libraries** (zlib, openssl, sqlite, libffi) successfully pass hyperlight multi-process and single-process tests. This strongly suggests the underlying runtime issue has been resolved.

## Changes

- **`nanvix.toml`**: Remove both `[[builds.exclude]]` entries
- **`nanvix-ci.yml`**: Replace `matrix-exclude` with explicit `platforms` and `process-modes` parameters matching the standard pattern used by zlib, openssl, sqlite, and libffi

## Impact

This unblocks downstream consumers like cpython that depend on bzip2 for all hyperlight platform/mode combinations.