### PR TITLE
[ci] E: Pin nanvix to v0.12.491

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -31,6 +31,8 @@ jobs:
       platforms: '["hyperlight","microvm"]'
       process-modes: '["multi-process","single-process","standalone"]'
       memory-sizes: '["128mb","256mb"]'
+      matrix-exclude: '[{"platform":"hyperlight"}]'
+      windows-matrix-exclude: '[{"platform":"hyperlight"}]'
       skip-full-test-modes: '[]'
       caller-event-name: ${{ github.event_name }}
       windows-test: true
@@ -51,6 +53,8 @@ jobs:
       platforms: '["hyperlight","microvm"]'
       process-modes: '["multi-process","single-process","standalone"]'
       memory-sizes: '["128mb","256mb"]'
+      matrix-exclude: '[{"platform":"hyperlight"}]'
+      windows-matrix-exclude: '[{"platform":"hyperlight"}]'
       skip-full-test-modes: '[]'
       caller-event-name: 'schedule'
       windows-test: true

--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bzip2"
 version = "1.0.8"
-nanvix-version = "0.12.490"
+nanvix-version = "0.12.491"
 
 [builds]
 [builds.matrix]


### PR DESCRIPTION
Automated bump of `nanvix-version` to [`v0.12.491`](https://github.com/nanvix/nanvix/releases/tag/v0.12.491).

Generated by the [Nanvix CI](https://github.com/nanvix/workflows/blob/main/.github/workflows/nanvix-ci.yml) reusable workflow.