### PR TITLE
[ci] Enable hyperlight platform in build matrix

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -31,8 +31,8 @@ jobs:
       platforms: '["hyperlight","microvm"]'
       process-modes: '["multi-process","single-process","standalone"]'
       memory-sizes: '["128mb","256mb"]'
-      matrix-exclude: '[{"platform":"hyperlight"}]'
-      windows-matrix-exclude: '[{"platform":"hyperlight"}]'
+      matrix-exclude: '[{"platform":"hyperlight","process-mode":"multi-process"},{"platform":"hyperlight","process-mode":"single-process"}]'
+      windows-matrix-exclude: '[]'
       skip-full-test-modes: '[]'
       caller-event-name: ${{ github.event_name }}
       windows-test: true
@@ -53,8 +53,8 @@ jobs:
       platforms: '["hyperlight","microvm"]'
       process-modes: '["multi-process","single-process","standalone"]'
       memory-sizes: '["128mb","256mb"]'
-      matrix-exclude: '[{"platform":"hyperlight"}]'
-      windows-matrix-exclude: '[{"platform":"hyperlight"}]'
+      matrix-exclude: '[{"platform":"hyperlight","process-mode":"multi-process"},{"platform":"hyperlight","process-mode":"single-process"}]'
+      windows-matrix-exclude: '[]'
       skip-full-test-modes: '[]'
       caller-event-name: 'schedule'
       windows-test: true

--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -31,7 +31,9 @@ jobs:
       platforms: '["hyperlight","microvm"]'
       process-modes: '["multi-process","single-process","standalone"]'
       memory-sizes: '["128mb","256mb"]'
-      matrix-exclude: '[{"platform":"hyperlight","process-mode":"multi-process"},{"platform":"hyperlight","process-mode":"single-process"}]'
+      matrix-exclude: >-
+        [{"platform":"hyperlight","process-mode":"multi-process"},
+        {"platform":"hyperlight","process-mode":"single-process"}]
       windows-matrix-exclude: '[]'
       skip-full-test-modes: '[]'
       caller-event-name: ${{ github.event_name }}
@@ -53,7 +55,9 @@ jobs:
       platforms: '["hyperlight","microvm"]'
       process-modes: '["multi-process","single-process","standalone"]'
       memory-sizes: '["128mb","256mb"]'
-      matrix-exclude: '[{"platform":"hyperlight","process-mode":"multi-process"},{"platform":"hyperlight","process-mode":"single-process"}]'
+      matrix-exclude: >-
+        [{"platform":"hyperlight","process-mode":"multi-process"},
+        {"platform":"hyperlight","process-mode":"single-process"}]
       windows-matrix-exclude: '[]'
       skip-full-test-modes: '[]'
       caller-event-name: 'schedule'


### PR DESCRIPTION
## Summary

- Remove `matrix-exclude` and `windows-matrix-exclude` entries that were disabling the hyperlight platform in CI
- Hyperlight was already declared in the build matrix (`platforms: ["hyperlight","microvm"]`) but excluded at the workflow level — this unblocks it

Depends on the Hyperlight HAL frame allocator fix in nanvix/nanvix which resolves the `frame allocator storage too small for sparse layout` kernel panic in standalone mode.

## Issues

- Closes #183 
- Closes #184 