### PR TITLE
[ci] E: Pin nanvix to v0.13.3

### DIFF
--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bzip2"
 version = "1.0.8"
-nanvix-version = "0.12.552"
+nanvix-version = "0.13.3"
 
 [builds]
 [builds.matrix]


### PR DESCRIPTION
Automated bump of `nanvix-version` to [`v0.13.3`](https://github.com/nanvix/nanvix/releases/tag/v0.13.3).

Generated by the [Nanvix CI](https://github.com/nanvix/workflows/blob/main/.github/workflows/nanvix-ci.yml) reusable workflow.