### PR TITLE
fix(ci): grant packages: read for nanvix/workflows@v2.0.1+ reusable

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -17,6 +17,7 @@ permissions:
   actions: write
   issues: write
   pull-requests: write
+  packages: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name || github.ref || 'default' }}


### PR DESCRIPTION
## Why

`nanvix/workflows` v2.0.1 ([commit 48eeaf7](https://github.com/nanvix/workflows/commit/48eeaf7)) added `packages: read` to the reusable workflow's top-level `permissions:` block so it can authenticate to ghcr.io.

GitHub Actions enforces that a reusable workflow's effective permissions must be ≤ the caller job's granted permissions. Our explicit `permissions:` block here omits `packages` (which then implicitly defaults to `none`), so as soon as the automation bump PR moves the ref to `@v2.0.1` the whole run fails with `startup_failure` (zero jobs created).

This is why the currently-open [`automation/update-nanvix-workflows` PR](https://github.com/nanvix/bzip2/pulls?q=is%3Apr+head%3Aautomation%2Fupdate-nanvix-workflows) shows a 0s startup_failure and never auto-merges.

## What

Adds a single line — `packages: read` — to the workflow-level `permissions:` block. Both `ci` and `ci-scheduled` calling jobs inherit from it.

## After merging

Re-run the failed startup_failure run on the open `automation/update-nanvix-workflows` PR. The rerun rebuilds the merge commit against this updated default branch, so the `@v2.0.1` reusable workflow picks up the granted permission, CI runs to completion, and the reusable's auto-merge job lands the bump PR.