### PR TITLE
[ci] Sync zutils v0.8.5

### DIFF
--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bzip2"
 version = "1.0.8"
-nanvix-version = "0.13.16"
+nanvix-version = "0.13.17"
 
 [builds]
 [builds.matrix]


### PR DESCRIPTION
Automated sync with [`v0.8.5`](https://github.com/nanvix/zutils/releases/tag/v0.8.5):
- Bumps `zutil-version` in caller workflows.
- Copies bootstrapper templates (`z`, `z.sh`, `z.ps1`) from release assets.
- Pins `nanvix-version` to `0.13.17` in `.nanvix/nanvix.toml`.

Generated by the [Update Zutils](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-zutils.yml) workflow.