### PR TITLE
[nanvix] Improve gitignore rules for Nanvix build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ builddir
 *.obj
 *.res
 *.o
+
+# Nanvix
+bzip2.elf

--- a/.nanvix/.gitignore
+++ b/.nanvix/.gitignore
@@ -6,5 +6,4 @@ buildroot/
 .yamllint.yml
 black.toml
 env.json
-nanvix.lock
 pyrightconfig.json


### PR DESCRIPTION
## Summary

Two small improvements to the Nanvix-related ignore rules:

- **Track `nanvix.lock`**: Removes `nanvix.lock` from `.nanvix/.gitignore` so the lock file can be committed alongside the rest of the Nanvix build configuration, ensuring reproducible builds via pinned dependency versions.
- **Ignore `bzip2.elf`**: Adds a "Nanvix" section to the top-level `.gitignore` excluding the `bzip2.elf` binary produced by the Nanvix build, preventing the compiled ELF from being accidentally committed.

## Changes

- `.nanvix/.gitignore`: drop `nanvix.lock` entry
- `.gitignore`: ignore `bzip2.elf`