### PR TITLE
[nanvix] Drop smoke/integration test tiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ builddir
 
 # Nanvix
 bzip2.elf
+nanvixd_*.log

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 from nanvix_zutil import (
     CFG_SYSROOT,
+    EXIT_INVALID_ARGS,
     EXIT_MISSING_DEP,
     TOOLCHAIN_CONTAINER_PATH,
     DockerConfig,
@@ -118,40 +119,39 @@ class Bzip2Build(ZScript):
     # Test
     # ------------------------------------------------------------------
 
-    def test(self) -> None:
-        """Run the test suite.
+    # Test targets accepted on the CLI.  Only functional tests remain
+    # after the smoke/integration tiers were removed from Makefile.nanvix.
+    _SUPPORTED_TEST_TARGETS = frozenset({"test", "test-functional"})
 
-        Smoke and integration tests are always delegated to the Makefile.
-        The functional test in standalone mode is handled in Python via
-        make_initrd so that initrd creation is shared across platforms.
+    def test(self) -> None:
+        """Run the functional test suite.
+
+        Compresses and decompresses sample data through the bzip2 binary
+        running under nanvixd.  In standalone mode the run is driven from
+        Python (via :func:`make_initrd`); in single-/multi-process modes
+        it is delegated to ``make test-functional``.
+
+        Any CLI-supplied targets (``./z test <target>...``) must be a
+        subset of :attr:`_SUPPORTED_TEST_TARGETS`; unknown targets are
+        rejected so they are not silently dropped.
         """
+        targets = self.targets or []
+        unknown = [t for t in targets if t not in self._SUPPORTED_TEST_TARGETS]
+        if unknown:
+            log.fatal(
+                f"Unsupported test target(s): {', '.join(unknown)}. "
+                f"Supported: {', '.join(sorted(self._SUPPORTED_TEST_TARGETS))}.",
+                code=EXIT_INVALID_ARGS,
+            )
+
         if is_windows():
             self._run_tests_windows()
             return
 
         if self.config.deployment_mode == "standalone":
-            targets = self.targets if self.targets else []
-            # Targets that require the Python functional path.
-            _functional_targets = {"test", "test-functional"}
-            needs_functional = not targets or bool(set(targets) & _functional_targets)
-            # Delegate non-functional targets to the Makefile.
-            make_targets = [t for t in targets if t not in _functional_targets]
-            if not targets:
-                make_targets = ["test-smoke", "test-integration"]
-            elif needs_functional and not make_targets:
-                # Ensure Makefile prerequisites run when only functional
-                # targets are requested (build + smoke/integration).
-                if "test" in targets:
-                    make_targets = ["test-smoke", "test-integration"]
-                else:
-                    make_targets = ["test-integration"]
-            if make_targets:
-                run(*self._make_args(*make_targets), cwd=self.repo_root)
-            if needs_functional:
-                self._run_functional_standalone()
+            self._run_functional_standalone()
         else:
-            targets = self.targets if self.targets else ["test"]
-            run(*self._make_args(*targets), cwd=self.repo_root)
+            run(*self._make_args("test-functional"), cwd=self.repo_root)
 
     def _run_functional_standalone(self) -> None:
         """Run standalone functional tests using make_initrd.

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -6,10 +6,8 @@
 #
 # Targets:
 #   all: Build the default target
-#   test: Run all tests (smoke, integration, functional)
-#   test-smoke: Verify build artifacts (no runtime needed)
-#   test-integration: Build and link bzip2 executable
-#   test-functional: Compress/decompress roundtrip tests on nanvixd$(EXE)
+#   test-functional: Run functional tests (compress/decompress roundtrips on nanvixd$(EXE))
+#   test: Alias for test-functional
 #   package: Create a release tarball with build artifacts and headers
 #   verify-package: Verify the contents of the release tarball
 #   clean: Remove build artifacts and test executables
@@ -90,30 +88,9 @@ bzip2$(EXE): bzip2.o $(STATICLIB)
 # Test Targets
 # ===========================================================================
 
-_check-bin:
-	@test -f $(PROG) || { echo "  FAIL: $(PROG) not found"; exit 1; }
-	@echo "  OK: $(PROG) ($$(wc -c < $(PROG)) bytes)"
-
-# --- Smoke tests: verify build artifacts (no runtime needed) ---
-test-smoke:
-	@echo "=== bzip2 smoke tests ==="
-	@echo "  Checking libbz2.a..."
-	@test -f $(STATICLIB) || { echo "  FAIL: $(STATICLIB) not found"; exit 1; }
-	@size=$$(wc -c < $(STATICLIB)); \
-	if [ "$$size" -lt 1000 ]; then echo "  FAIL: $(STATICLIB) too small ($$size bytes)"; exit 1; fi
-	@echo "  Checking headers..."
-	@test -f bzlib.h || { echo "  FAIL: bzlib.h not found"; exit 1; }
-	@echo "  PASS: bzip2 smoke tests"
-
-# --- Integration tests: build and link bzip2 executable ---
-test-integration: _check-bin
-	@echo "=== bzip2 integration tests ==="
-	@test -f bzip2$(EXE) || { echo "  FAIL: bzip2$(EXE) not built"; exit 1; }
-	@echo "  OK: bzip2$(EXE) ($$(wc -c < bzip2$(EXE)) bytes)"
-	@echo "  PASS: bzip2 integration tests"
-
 # --- Functional tests: compress/decompress roundtrip on nanvixd$(EXE) ---
-test-functional: test-integration
+test-functional:
+	@test -f $(PROG) || { echo "  FAIL: $(PROG) not found"; exit 1; }
 	@echo "=== bzip2 functional tests ==="
 ifeq ($(PROCESS_MODE),standalone)
 	@echo "  NOTE: Standalone functional tests are handled via ./z.sh."
@@ -159,8 +136,8 @@ else
 endif
 	@echo "  PASS: bzip2 functional tests"
 
-# --- Run all test levels ---
-test: test-smoke test-integration test-functional
+# --- Run tests (alias for functional tests) ---
+test: test-functional
 	@echo "=== All bzip2 tests PASSED ==="
 
 # ===========================================================================
@@ -214,4 +191,4 @@ clean:
 	rm -f *.a *$(EXE)
 	rm -rf dist/
 
-.PHONY: all clean test test-smoke test-integration test-functional package verify-package
+.PHONY: all clean test test-functional package verify-package


### PR DESCRIPTION
The smoke and integration Makefile tiers added little value beyond what the functional test already exercises: smoke only stat'd libbz2.a and bzlib.h, and integration only re-checked that bzip2$(EXE) exists. The functional test already requires both artifacts in order to run a real compress/decompress roundtrip under nanvixd, so the earlier tiers were redundant.

Makefile.nanvix:
  - Remove _check-bin, test-smoke, and test-integration targets.
  - Inline the bzip2$(EXE) existence check into test-functional so the binary precondition is still enforced.
  - Reduce `test` to a thin alias for `test-functional`.
  - Update header documentation and .PHONY accordingly.

.nanvix/z.py (Bzip2Build.test):
  - Replace the target-routing logic (which mixed Makefile smoke/ integration calls with the Python functional path) with a single dispatch:
      * standalone  -> _run_functional_standalone()
      * single/multi-process -> make test-functional
  - Introduce _SUPPORTED_TEST_TARGETS = {"test", "test-functional"} and validate self.targets against it, so unknown CLI test targets fail fast instead of being silently dropped.
  - Refresh the docstring to describe the new dispatch and the target validation rule.

No behavioural change for the functional suite itself; only the now-removed smoke/integration tiers are no longer reachable from either the Makefile or z.py.