### PR TITLE
[build] E: Build libbz2.so alongside libbz2.a

### DIFF
--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -117,9 +117,11 @@ class Bzip2Build(ZScript):
         output_files = [
             # In-tree build artifacts (legacy locations used by tests).
             "libbz2.a",
+            "libbz2.so",
             "bzip2.elf",
             # Installed artifacts staged for `./z release` / packaging.
             str((lib_out() / "libbz2.a").relative_to(root)),
+            str((lib_out() / "libbz2.so").relative_to(root)),
             str((include_out() / "bzlib.h").relative_to(root)),
             str((bin_out() / "bzip2.elf").relative_to(root)),
         ]
@@ -138,7 +140,7 @@ class Bzip2Build(ZScript):
     # ------------------------------------------------------------------
 
     def build(self) -> None:
-        """Cross-compile libbz2.a and bzip2.elf for Nanvix."""
+        """Cross-compile libbz2.a, libbz2.so, and bzip2.elf for Nanvix."""
         run(*self._make_args("all", "bzip2.elf"), cwd=repo_root(), docker=self.docker)
 
     # ------------------------------------------------------------------
@@ -489,7 +491,7 @@ class Bzip2Build(ZScript):
     def clean(self) -> None:
         """Remove build artifacts."""
         if is_windows():
-            for pattern in ["*.o", "*.a", "*.elf"]:
+            for pattern in ["*.o", "*.a", "*.so", "*.elf"]:
                 for f in repo_root().glob(pattern):
                     f.unlink()
             dist_dir = repo_root() / "dist"

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -23,7 +23,6 @@
 
 .DEFAULT_GOAL=all
 EXE = .elf
-_NANVIX_DOCKER_BUILD_GOALS := all install bzip2$(EXE)
 _NANVIX_GOALS := $(or $(MAKECMDGOALS),$(.DEFAULT_GOAL))
 
 # Ensure required variables are defined
@@ -35,13 +34,14 @@ ifneq ($(filter-out clean,$(_NANVIX_GOALS)),)
   )
 endif
 
-CFLAGS = -O2 -Wall -D_FILE_OFFSET_BITS=64 -DBZ_UNIX -DBZ_LCCWIN32=0
+CFLAGS = -O2 -Wall -fPIC -D_FILE_OFFSET_BITS=64 -DBZ_UNIX -DBZ_LCCWIN32=0
 ARFLAGS = rcs
 STATICLIB = libbz2.a
+SHAREDLIB = libbz2.so
 OBJS = blocksort.o huffman.o crctable.o randtable.o compress.o decompress.o bzlib.o
 PROG := bzip2$(EXE)
 SYSROOT_PATH := $(abspath $(NANVIX_HOME))
-LIB_ARTIFACTS := $(STATICLIB)
+LIB_ARTIFACTS := $(STATICLIB) $(SHAREDLIB)
 INCLUDE_ARTIFACTS := bzlib.h
 BIN_ARTIFACTS := $(PROG)
 RELEASE_ARTIFACTS := $(LIB_ARTIFACTS) $(INCLUDE_ARTIFACTS) $(BIN_ARTIFACTS)
@@ -50,6 +50,8 @@ RELEASE_ARTIFACTS := $(LIB_ARTIFACTS) $(INCLUDE_ARTIFACTS) $(BIN_ARTIFACTS)
 # Build Mode Variables
 # ===========================================================================
 
+# Defined here (after SHAREDLIB) so $(SHAREDLIB) expands to its value.
+_NANVIX_DOCKER_BUILD_GOALS := all install bzip2$(EXE) $(SHAREDLIB)
 _BUILD := $(filter $(_NANVIX_DOCKER_BUILD_GOALS),$(_NANVIX_GOALS))
 _NONBUILD := $(filter-out $(_NANVIX_DOCKER_BUILD_GOALS),$(_NANVIX_GOALS))
 ifneq ($(_BUILD),)
@@ -84,11 +86,11 @@ NANVIX_LIBS := -Wl,--start-group \
 # Build Targets
 # ===========================================================================
 
-all: $(STATICLIB) $(PROG) install
+all: $(STATICLIB) $(SHAREDLIB) $(PROG) install
 
 # Stage built artifacts into the release output tree so that
 # `./z release` (which packages release_dir()) can find them.
-install: $(STATICLIB) $(PROG)
+install: $(STATICLIB) $(SHAREDLIB) $(PROG)
 	@mkdir -p $(LIB_OUT) $(INCLUDE_OUT) $(BIN_OUT)
 	cp -f $(LIB_ARTIFACTS)     $(LIB_OUT)/
 	cp -f $(INCLUDE_ARTIFACTS) $(INCLUDE_OUT)/
@@ -96,6 +98,20 @@ install: $(STATICLIB) $(PROG)
 
 $(STATICLIB): $(OBJS)
 	$(AR) $(ARFLAGS) $@ $(OBJS)
+
+# Link libbz2.so from the (now PIC) static archive via --whole-archive
+# so every libbz2 entry point becomes part of the .so's .dynsym.  Set
+# DT_SONAME so consumers that link against this .so emit a proper
+# DT_NEEDED entry.  libbz2 is self-contained (no transitive .so deps),
+# so nothing else to record; `-nostdlib` keeps the libc/libm symbols
+# UND so they bind at dlopen time against the host executable's
+# .dynsym (the same model already used by other Nanvix shared
+# libraries such as libffi.so / libssl.so).
+$(SHAREDLIB): $(STATICLIB)
+	$(CC) -shared -fPIC -nostdlib \
+	    -Wl,-soname,$(SHAREDLIB) -Wl,-z,noexecstack \
+	    -Wl,--whole-archive $(STATICLIB) -Wl,--no-whole-archive \
+	    -o $@
 
 bzip2$(EXE): bzip2.o $(STATICLIB)
 	$(CC) $(CFLAGS) $(NANVIX_LDFLAGS) -o $@ bzip2.o -L. -lbz2 $(NANVIX_LIBS)
@@ -176,6 +192,7 @@ package:
 		dist/$(ARTIFACT_NAME)/sysroot/include \
 		dist/$(ARTIFACT_NAME)/sysroot/bin
 	cp -f $(STATICLIB) dist/$(ARTIFACT_NAME)/sysroot/lib/
+	cp -f $(SHAREDLIB) dist/$(ARTIFACT_NAME)/sysroot/lib/
 	cp -f bzlib.h dist/$(ARTIFACT_NAME)/sysroot/include/
 	cp -f $(PROG) dist/$(ARTIFACT_NAME)/sysroot/bin/
 	tar -czf dist/$(ARTIFACT_NAME).tar.gz -C dist/$(ARTIFACT_NAME) sysroot
@@ -196,8 +213,11 @@ verify-package:
 	fi; \
 	echo "Package contents:"; \
 	tar tzf "$$TARBALL"; \
-	if ! tar tzf "$$TARBALL" | grep -q 'sysroot/lib/'; then \
-	  echo "FAIL: Package missing sysroot/lib/ entries"; exit 1; \
+	if ! tar tzf "$$TARBALL" | grep -q 'sysroot/lib/libbz2.a$$'; then \
+	  echo "FAIL: Package missing sysroot/lib/libbz2.a"; exit 1; \
+	fi; \
+	if ! tar tzf "$$TARBALL" | grep -q 'sysroot/lib/libbz2.so$$'; then \
+	  echo "FAIL: Package missing sysroot/lib/libbz2.so"; exit 1; \
 	fi; \
 	echo "  PASS: bzip2 package verification"
 
@@ -206,8 +226,8 @@ verify-package:
 # ===========================================================================
 
 clean:
-	rm -f *.o $(STATICLIB) $(PROG)
-	rm -f *.a *$(EXE)
+	rm -f *.o $(STATICLIB) $(SHAREDLIB) $(PROG)
+	rm -f *.a *.so *$(EXE)
 	rm -rf dist/
 
 .PHONY: all install clean test test-functional package verify-package


### PR DESCRIPTION
## Summary

Adds a SHAREDLIB target to `Makefile.nanvix` so the bzip2 port builds `libbz2.so` alongside the existing `libbz2.a`. This lets consumers `dlopen` libbz2 at run time instead of statically linking it.

## Why

Today the Nanvix bzip2 port ships only `libbz2.a`. Anything that wants bzip2 (e.g., cpython's `_bz2` extension) has to statically embed it into the consumer binary. That works for cpython's monolithic `python.elf` but does not allow:

- Sharing a single libbz2 implementation across multiple `.so` consumers in the same process.
- Building a cpython `_bz2.so` that resolves bzip2 via `DT_NEEDED libbz2.so` (the model already used by `_ssl.so` → `libssl.so` and `_ctypes.so` → `libffi.so` on Nanvix).

Producing `libbz2.so` here unblocks the cpython migration of `_bz2` from `--whole-archive .a in python.elf` to `DT_NEEDED .so`.

## What changed

- `Makefile.nanvix`:
  - `STATICLIB = libbz2.a` joined by `SHAREDLIB = libbz2.so`.
  - `CFLAGS` gains `-fPIC` so the same `.o` files compile into both `.a` and `.so`.
  - New `$(SHAREDLIB)` rule links the `.so` from the `.a` via `-Wl,--whole-archive` with `DT_SONAME=libbz2.so` and `-nostdlib` (libc / libm UND, bind at dlopen).
  - `all`, `install`, `package`, `verify-package`, `clean`, `LIB_ARTIFACTS`, `_NANVIX_DOCKER_BUILD_GOALS` all extended to cover the `.so`.
- `.nanvix/z.py`: `output_files` extended with `libbz2.so` so `./z build` copies it back to the workspace and `./z release` packages it into the buildroot snapshot.

## Architecture

```
libbz2.so          69 KB
  └── UND libc / libm symbols (exit, fprintf, malloc, ...)
      → resolved against the host executable's .dynsym at dlopen time

libbz2.a (unchanged)
  └── same .o files compiled with -fPIC
```

`libbz2.so` has no transitive `.so` dependencies (libbz2 is self-contained; libc/libm symbols are UND), so the loader does not need to walk any DT_NEEDED chain to load it.

## Dependencies

**Runtime dep (already merged upstream):**

- [nanvix/nanvix#2473](https://github.com/nanvix/nanvix/pull/2473) — `dlfcn` init-array + DT_RUNPATH support. Required for any consumer to `dlopen("libbz2.so")` at run time.

## Validation

Build runs end-to-end inside the toolchain-gcc Docker image:

```
$ ./z build
... (compiles 7 .o files with -fPIC) ...
ar rcs libbz2.a blocksort.o huffman.o crctable.o randtable.o compress.o decompress.o bzlib.o
i686-nanvix-gcc -shared -fPIC -nostdlib \
    -Wl,-soname,libbz2.so -Wl,-z,noexecstack \
    -Wl,--whole-archive libbz2.a -Wl,--no-whole-archive \
    -o libbz2.so
success: Build complete
```

Structural verification of the produced `libbz2.so` (69 036 bytes):

```
$ i686-nanvix-readelf -d libbz2.so | head -8
Dynamic section at offset 0xf040 contains 15 entries:
  Tag        Type                         Name/Value
 0x0000000e (SONAME)                     Library soname: [libbz2.so]
 0x00000004 (HASH)                       0xb4
 ...

$ i686-nanvix-nm -D libbz2.so | grep ' T ' | head -8
00002b80 T BZ2_blockSort
00003990 T BZ2_bsInitWrite
0000d510 T BZ2_bzBuffToBuffCompress
0000d640 T BZ2_bzBuffToBuffDecompress
0000b1f0 T BZ2_bzCompress
0000b360 T BZ2_bzCompressEnd
0000afb0 T BZ2_bzCompressInit
0000b540 T BZ2_bzDecompress

$ i686-nanvix-nm -D libbz2.so | grep ' U ' | head -10
         U _ctype_
         U _impure_ptr
         U exit
         U fclose
         U fdopen
         U fflush
         U fgetc
         U fopen
         U fprintf
         U fputc
```

SONAME correctly set, all `BZ2_*` public API exported, libc symbols left UND for runtime binding. The existing `libbz2.a` and `bzip2.elf` test binary are unchanged.
